### PR TITLE
Fix region field name in docs

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -256,7 +256,7 @@ Returns full details of a deal including participants, roles, and people.
         "name": "ABC Corp",
         "profile": {
           "industry": "Healthcare Services",
-          "type": "North America",
+          "region": "North America",
           "employeeCount": 1200,
           "foundedYear": 2004,
           "ownership": "Private",


### PR DESCRIPTION
## Summary
- fix JSON example by renaming the `type` field to `region`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683f5d9ca374832eb658fa71722bc6ff